### PR TITLE
SEAB-7130: Require that the initial path point at a Snakefile

### DIFF
--- a/src/main/java/io/dockstore/language/SnakemakeWorkflowPlugin.java
+++ b/src/main/java/io/dockstore/language/SnakemakeWorkflowPlugin.java
@@ -40,6 +40,7 @@ public class SnakemakeWorkflowPlugin extends Plugin {
 
     public static final Logger LOG = LoggerFactory.getLogger(SnakemakeWorkflowPlugin.class);
     public static final String SNAKEMAKE_WORKFLOW_CATALOG_YML = "/.snakemake-workflow-catalog.yml";
+    public static final String INVALID_INITIAL_PATH_MESSAGE = "the primary descriptor path must be the Snakefile";
 
 
     /**
@@ -63,6 +64,10 @@ public class SnakemakeWorkflowPlugin extends Plugin {
 
         @Override
         public VersionTypeValidation validateWorkflowSet(String initialPath, String contents, Map<String, FileMetadata> indexedFiles) {
+            // if the initial path doesn't point at the Snakefile, the version is invalid
+            if (!initialPathPattern().matcher(initialPath).matches()) {
+                return new VersionTypeValidation(false, Map.of(initialPath, INVALID_INITIAL_PATH_MESSAGE));
+            }
             VersionTypeValidation validation = new VersionTypeValidation(indexedFiles.containsKey(SNAKEMAKE_WORKFLOW_CATALOG_YML), new HashMap<>());
             // TODO hook up some real validation
             return validation;
@@ -86,7 +91,7 @@ public class SnakemakeWorkflowPlugin extends Plugin {
          */
         @Override
         public Pattern initialPathPattern() {
-            return Pattern.compile("workflow/Snakefile");
+            return Pattern.compile("(/.*)?/[Ss]nakefile");
         }
 
         @Override


### PR DESCRIPTION
This PR updates the snakemake plugin so that the initial path must point at a `Snakefile` for the resulting version to be valid.  It also changes the `initialPathPattern` to match any absolute path that ends with `/Snakefile` or `/snakefile` (see the documentation for the `--snakefile` option for why we would support the lowercase name https://snakemake.readthedocs.io/en/stable/executing/cli.html).

The goal is to prevent any valid Snakemake versions from having a primary descriptor that isn't the Snakefile.

Some notes and observations:

* The plugin `initialPathPattern` method does not appear to be used anywhere in our codebase, other than to output some diagnostic information.  One might expect our workflow registration code to confirm that the initial path matches the pattern, but it does not.  Essentially, this PR implements this type of check in the Snakemake plugin, only, to avoid breaking existing workflows of other types that might fail such a test.

* Currently, there is no defined way for a plugin to intentionally signal an exceptional condition to the surrounding code, in a way that the surrounding code can tell the difference between the intentional exception and and some other type of `RuntimeException` that resulted from a bug.  Such a mechanism would be useful in cases that the plugin purposefully wanted to "throw up its hands",  stop, and propagate a reason to the surrounding code.

* The `FileReader` interface is functionally very similar to the `FileTree` abstraction introduced by the inference code.  It is my belief that, conceptually, they are analogs.

* If we're serious about using the plugin architecture to support more workflow types, we should assess its architecture to make sure it is flexible enough to field all of the possible workflow types we might throw at it.  Sooner we do this, the less plugins we'll need to rewrite.

* Our registration code has some pretty deep spaghetti in spots, through which the repo access code is interleaved.  At some point, when we have the time, it would be great to refactor.  It would take a while, but make the code much easier to understand and maintain, and give us the ability to do some interesting new stuff.
