### PR TITLE
Add validation message for missing workflow catalog file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,6 @@
 *.class
+.idea
+target
 
 # Mobile Tools for Java (J2ME)
 .mtj.tmp/

--- a/src/main/java/io/dockstore/language/SnakemakeWorkflowPlugin.java
+++ b/src/main/java/io/dockstore/language/SnakemakeWorkflowPlugin.java
@@ -41,6 +41,7 @@ public class SnakemakeWorkflowPlugin extends Plugin {
     public static final Logger LOG = LoggerFactory.getLogger(SnakemakeWorkflowPlugin.class);
     public static final String SNAKEMAKE_WORKFLOW_CATALOG_YML = "/.snakemake-workflow-catalog.yml";
     public static final String INVALID_INITIAL_PATH_MESSAGE = "the primary descriptor path must be the Snakefile";
+    public static final String MISSING_WORKFLOW_CATALOG_MESSAGE = "the Snakemake workflow catalog file is missing";
 
 
     /**
@@ -68,7 +69,7 @@ public class SnakemakeWorkflowPlugin extends Plugin {
             if (!initialPathPattern().matcher(initialPath).matches()) {
                 return new VersionTypeValidation(false, Map.of(initialPath, INVALID_INITIAL_PATH_MESSAGE));
             }
-            VersionTypeValidation validation = new VersionTypeValidation(indexedFiles.containsKey(SNAKEMAKE_WORKFLOW_CATALOG_YML), new HashMap<>());
+            VersionTypeValidation validation = new VersionTypeValidation(indexedFiles.containsKey(SNAKEMAKE_WORKFLOW_CATALOG_YML), Map.of(SNAKEMAKE_WORKFLOW_CATALOG_YML, MISSING_WORKFLOW_CATALOG_MESSAGE));
             // TODO hook up some real validation
             return validation;
         }


### PR DESCRIPTION
https://ucsc-cgl.atlassian.net/browse/SEAB-7142

This PR adds a validation message if the .snakemake-workflow-catalog.yml file is missing:

![image](https://github.com/user-attachments/assets/72d9f9b0-827c-44bc-a753-56d7e53bfefa)

Is this okay going to develop? Or should I create a release branch?

**Review Instructions**
Try to recreate the bug in the ticket description https://ucsc-cgl.atlassian.net/browse/SEAB-7142. You should see a validation message in the warning banner stating that the snakemake catalog file is missing.